### PR TITLE
[api] return `202` on successful CSR submit

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -46,8 +46,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/ca.PostCSRResponse"
                         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -43,8 +43,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/ca.PostCSRResponse"
                         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -98,8 +98,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Accepted
           schema:
             $ref: '#/definitions/ca.PostCSRResponse'
         "400":

--- a/internal/api/csr.go
+++ b/internal/api/csr.go
@@ -22,7 +22,7 @@ type csrHandler struct {
 //	@Accept		json
 //	@Produce	json
 //	@Param		request	body		ca.PostCSRRequest	true	"Request"
-//	@Success	200		{object}	ca.PostCSRResponse
+//	@Success	202		{object}	ca.PostCSRResponse
 //	@Failure	400		{object}	http.JSONErrorResponse
 //	@Failure	500		{object}	http.JSONErrorResponse
 //	@Router		/csr [post]
@@ -39,12 +39,14 @@ func (c *csrHandler) submit(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	return ctx.JSON(ca.PostCSRResponse{
-		RequestID:   res.ID(),
-		Status:      res.Status(),
-		Message:     res.Status().Description(),
-		Certificate: res.Certificate(),
-	})
+	return ctx.
+		Status(fiber.StatusAccepted).
+		JSON(ca.PostCSRResponse{
+			RequestID:   res.ID(),
+			Status:      res.Status(),
+			Message:     res.Status().Description(),
+			Certificate: res.Certificate(),
+		})
 }
 
 //	@Summary	Get CSR Status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the API’s submission response to return a 202 Accepted status, clarifying that requests are queued for processing rather than marked as immediately completed.
- **Documentation**
  - Revised API documentation to reflect the change in response status from 200 OK to 202 Accepted for the `/csr` POST endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->