### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/ca-backend/security/code-scanning/1](https://github.com/android-sms-gateway/ca-backend/security/code-scanning/1)

To fix the issue, we need to explicitly define the permissions for the workflow. Since the workflow performs basic CI tasks such as linting and testing, it only requires `contents: read` permissions. We will add a `permissions` block at the root level of the workflow to apply these permissions to all jobs. This ensures that the `GITHUB_TOKEN` has the minimal access required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to specify repository permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->